### PR TITLE
Make generate Pkg(3) compliant.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,9 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 DocStringExtensions = ">= 0.2"
 
 [extras]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Example", "Pkg", "Test"]

--- a/src/DocumenterTools.jl
+++ b/src/DocumenterTools.jl
@@ -8,91 +8,140 @@ include("Travis.jl")
 include("Generator.jl")
 
 """
-$(SIGNATURES)
+    DocumenterTools.generate(path::String; name = nothing)
 
-Creates a documentation stub for a package called `pkgname`. The location of
-the documentation is assumed to be `<package directory>/docs`, but this can
-be overriden with the keyword argument `dir`.
+Create a documentation stub in `path`, which is usually a sub folder in
+the package root. The name of the package is determined automatically,
+but can be given with the `name` keyword argument.
 
-It creates the following files
+`generate` creates the following files in `path`:
 
 ```
-docs/
-    .gitignore
-    src/index.md
-    make.jl
-    mkdocs.yml
+.gitignore
+src/index.md
+make.jl
+mkdocs.yml
 ```
 
 # Arguments
 
-**`pkgname`** is the name of the package (without `.jl`). It is used to
-determine the location of the documentation if `dir` is not provided.
+**`path`** file path to the documentation directory.
 
-# Keywords
+# Keywords Arguments
 
-**`dir`** defines the directory where the documentation will be generated.
-It defaults to `<package directory>/docs`. The directory must not exist.
+**`name`** is the name of the package (without `.jl`). If `name` is not given
+`generate` tries to detect it automatically.
 
 # Examples
+```julia-repl
+julia> using DocumenterTools
 
+julia> Documenter.generate("path/to/MyPackage/docs")
+[ ... output ... ]
+```
+"""
+function generate(path::AbstractString; name::Union{AbstractString,Nothing}=nothing)
+    # TODO:
+    #   - set up deployment to `gh-pages`
+    #   - fetch url and username automatically (e.g from git remote.origin.url)
+
+    path = abspath(path)
+    if isdir(path)
+        throw(ArgumentError("directory `$(Base.contractuser(path))` already exists."))
+    end
+
+    # determine name of package unless it is given
+    if name === nothing
+        srcdir = normpath(joinpath(path, "..", "src"))
+        candidates = String[]
+        if isdir(srcdir)
+            for file in readdir(srcdir)
+                if isfile(joinpath(srcdir, file))
+                    modulename = splitext(file)[1]
+                    str = read(joinpath(srcdir, file), String)
+                    i = findfirst(Regex("module\\s+" * modulename), str)
+                    i !== nothing && push!(candidates, modulename)
+                end
+            end
+        end
+        if length(candidates) != 1 # || name === nothing
+            throw(ArgumentError(string("could not determine name of package located ",
+                "in `$(Base.contractuser(normpath(joinpath(path, ".."))))`. ",
+                "Please specify the `name` keyword argument to `DocumenterTools.generate`.")))
+        end
+        name = candidates[1]
+        @info("name of package automatically determined to be `$(name)`.")
+    end
+    @assert name !== nothing
+
+    # deploy the stub
+    try
+        @info("deploying documentation to `$(Base.contractuser(path))`")
+        mkdir(path)
+
+        # create the root doc files
+        Generator.savefile(path, ".gitignore") do io
+            write(io, Generator.gitignore())
+        end
+        Generator.savefile(path, "make.jl") do io
+            write(io, Generator.make(name))
+        end
+        Generator.savefile(path, "mkdocs.yml") do io
+            write(io, Generator.mkdocs(name))
+        end
+
+        # Create the default documentation source files
+        Generator.savefile(path, "src/index.md") do io
+            write(io, Generator.index(name))
+        end
+    catch
+        rm(path, recursive=true)
+        rethrow()
+    end
+    nothing
+end
+
+"""
+    DocumenterTools.generate(pkg::Module; dir = "docs")
+
+Same as `generate(path::String)` but the `path` and name is determined
+automatically from the module.
+
+!!! note
+    The package must be in development mode. Make sure you run
+    `pkg> develop pkg` from the Pkg REPL, or `Pkg.develop(\"pkg\")`
+    before generating docs.
+
+# Examples
 ```julia-repl
 julia> using DocumenterTools
 
 julia> using MyPackage
 
-julia> Documenter.generate(MyPackage)
+julia> DocumenterTools.generate(MyPackage)
 [ ... output ... ]
 ```
 """
-function generate(pkg::Module; dir=nothing)
-    # TODO:
-    #   - set up deployment to `gh-pages`
-    #   - fetch url and username automatically (e.g from git remote.origin.url)
-
-    # Assume the package name
-    pkgname = string(pkg) * ".jl"
-    # Determine the root directory where we wish to generate the docs and
-    # check that it is a valid directory.
-    docroot = if dir === nothing
-        pkgdir = dirname(dirname(pathof(pkg)))
-        if !isdir(pkgdir)
-            error("Unable to find package $(pkgname).jl at $(pkgdir).")
+function generate(pkg::Module; dir = "docs")
+    pkg == parentmodule(pkg) || throw(ArgumentError("can't add documentation to a submodule."))
+    name = String(nameof(pkg))
+    path = pathof(pkg)
+    path === nothing && throw(ArgumentError("could not find path to $(pkg)."))
+    # check that pkg is not originating from a standard installation directory
+    # since those are supposed to be immutable.
+    for depot in DEPOT_PATH
+        sep = Sys.iswindows() ? "\\\\" : "/"
+        if startswith(path, joinpath(depot, "packages", name)) &&
+            occursin(Regex(name * sep * "\\w{4,5}" * sep * "src" * sep * name * ".jl"), path)
+            throw(ArgumentError(string(
+                "module $(name) was found in a standard installation directory. ",
+                "Please make sure that $(name) is ready for development by running ",
+                "`pkg> develop $(name)` from the Pkg REPL, or ",
+                "`Pkg.develop(\"$(name)\")` from the Julia REPL, and try again.")))
         end
-        joinpath(pkgdir, "docs")
-    else
-        dir
     end
-
-    if ispath(docroot)
-        error("Directory $(docroot) already exists.")
-    end
-
-    # deploy the stub
-    try
-        @info("Deploying documentation to $(docroot)")
-        mkdir(docroot)
-
-        # create the root doc files
-        Generator.savefile(docroot, ".gitignore") do io
-            write(io, Generator.gitignore())
-        end
-        Generator.savefile(docroot, "make.jl") do io
-            write(io, Generator.make(pkgname))
-        end
-        Generator.savefile(docroot, "mkdocs.yml") do io
-            write(io, Generator.mkdocs(pkgname))
-        end
-
-        # Create the default documentation source files
-        Generator.savefile(docroot, "src/index.md") do io
-            write(io, Generator.index(pkgname))
-        end
-    catch
-        rm(docroot, recursive=true)
-        rethrow()
-    end
-    nothing
+    return generate(normpath(joinpath(path, "..", "..", dir)); name = name)
 end
+
 
 end # module


### PR DESCRIPTION
This makes some changes in the API, you can now do
```julia
DocumenterTools.generate(Foo)
```
where `Foo` is a module, or
```julia
DocumenterTools.generate("path/to/Foo/docs")
```

fix #2