### PR TITLE
Quote the URL in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ documentation][documenter-docs].
 
 ## Installation
 
-The package can be added using the Julia package manager. From the Julia REPL, type `]` to
-enter the Pkg REPL mode and run
+The package is currently unregistered and must be added via URL in the package manager.
+From the Julia REPL, type `]` to enter the Pkg REPL mode and run
 
 ```
-pkg> add DocumenterTools
+pkg> add https://github.com/JuliaDocs/DocumenterTools.jl.git
 ```
 
 [documenter]: https://github.com/JuliaDocs/Documenter.jl


### PR DESCRIPTION
In response to #8 -- best to have working installation instructions. Needs to be changed back when we registered, of course.