### PR TITLE
Declare compat with Documenter 0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version `v0.1.6`
 
-Maintenance release declaring compatibility with Documenter 0.25.
+Maintenance release declaring compatibility with Documenter 0.25. ([#39][github-39])
 
 ## Version `v0.1.5`
 
@@ -38,6 +38,7 @@ Maintenance release declaring compatibility with Documenter 0.25.
 [github-32]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/32
 [github-33]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/33
 [github-35]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/35
+[github-39]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/39
 
 
 [badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DocumenterTools.jl changelog
 
+## Version `v0.1.6`
+
+Maintenance release declaring compatibility with Documenter 0.25.
+
 ## Version `v0.1.5`
 
 * ![Bugfix][badge-bugfix] Fixes to the `Themes.compile` function, including making sure that the Sass include path is properly set up. ([#32][github-32], [#35][github-35])

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocumenterTools"
 uuid = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -11,7 +11,7 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Sass = "322a6be2-4ae8-5d68-aaf1-3e960788d1d9"
 
 [compat]
-Documenter = "0.20, 0.21, 0.22, 0.23, 0.24"
+Documenter = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 Sass = "0.1"
 DocStringExtensions = "0.7, 0.8"
 julia = "1"


### PR DESCRIPTION
And set version to 0.1.6 for tagging a new release. In preparation for JuliaDocs/Documenter.jl#1334.