### PR TITLE
Specify "Documenter" as the SSH key comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DocumenterTools.jl changelog
 
+## Version `v0.1.7`
+
+* ![Enhancement][badge-enhancement] `DocumenterTools.genkeys` now puts "Documenter" as the comment in the SSH key file, instead of the default username and hostname. ([#40][github-40])
+
 ## Version `v0.1.6`
 
 Maintenance release declaring compatibility with Documenter 0.25. ([#39][github-39])
@@ -39,6 +43,7 @@ Maintenance release declaring compatibility with Documenter 0.25. ([#39][github-
 [github-33]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/33
 [github-35]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/35
 [github-39]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/39
+[github-40]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/40
 
 
 [badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg

--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,9 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Sass = "322a6be2-4ae8-5d68-aaf1-3e960788d1d9"
 
 [compat]
+DocStringExtensions = "0.7, 0.8"
 Documenter = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 Sass = "0.1"
-DocStringExtensions = "0.7, 0.8"
 julia = "1"
 
 [extras]

--- a/src/genkeys.jl
+++ b/src/genkeys.jl
@@ -73,7 +73,7 @@ function genkeys(; user="\$USER", repo="\$REPO")
     isfile("$(filename).pub") && error("temporary file '$(filename).pub' already exists in working directory")
 
     # Generate the ssh key pair.
-    success(`ssh-keygen -N "" -f $filename`) || error("failed to generate a SSH key pair.")
+    success(`ssh-keygen -N "" -C Documenter -f $filename`) || error("failed to generate a SSH key pair.")
 
     # Prompt user to add public key to github then remove the public key.
     let url = "https://github.com/$user/$repo/settings/keys"


### PR DESCRIPTION
It's more useful to see that the public key for a repository is named "Documenter" rather than using the default username and hostname.