### PR TITLE
Fix broken link

### DIFF
--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -9,7 +9,7 @@ using DocStringExtensions
 $(SIGNATURES)
 
 Attempts to save a file at `\$(root)/\$(filename)`. `f` will be called with file
-stream (see [`open`](https://docs.julialang.org/en/latest/base/io-network/#Base.open)).
+stream (see [`open`](https://docs.julialang.org/en/v1/base/io-network/#Base.open)).
 
 `filename` can also be a file in a subdirectory (e.g. `src/index.md`), and then
 then subdirectories will be created automatically.


### PR DESCRIPTION
This is trivial, but fixes one of two errors in the Linkcheck of Documenter.jl.