### PR TITLE
Make sure that the generated private key is in PEM format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * DocumenterTools now requires at least Julia 1.6.
 * ![Enhancement][badge-enhancement] `DocumenterTools.genkeys` function now uses the `OpenSSH_jll` for the `ssh-keygen` binary and therefore no longer requires the user to have OpenSSH installed. ([#36][github-36], [#56][github-56])
+* ![Bugfix][badge-bugfix] DocumenterTools now always generated the SSH keys in the PEM file format to make sure that they also work on older systems. ([#48][github-48])
 
 ## Version `v0.1.13`
 
@@ -77,6 +78,7 @@ Maintenance release declaring compatibility with Documenter 0.25. ([#39][github-
 [github-43]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/43
 [github-44]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/44
 [github-46]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/46
+[github-48]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/48
 [github-49]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/49
 [github-51]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/51
 [github-52]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/52

--- a/src/genkeys.jl
+++ b/src/genkeys.jl
@@ -73,7 +73,7 @@ function genkeys(; user="\$USER", repo="\$REPO")
     isfile("$(filename).pub") && error("temporary file '$(filename).pub' already exists in working directory")
 
     # Generate the ssh key pair.
-    success(`ssh-keygen -N "" -C Documenter -f $filename`) || error("failed to generate a SSH key pair.")
+    success(`ssh-keygen -N "" -C Documenter -m PEM -f $filename`) || error("failed to generate a SSH key pair.")
 
     # Prompt user to add public key to github then remove the public key.
     let url = "https://github.com/$user/$repo/settings/keys"


### PR DESCRIPTION
It looks like the default key format generated by `ssh-keygen` has been changed away from PEM (in OpenSSH 8 it looks like; private key files now start with `BEGIN OPENSSH PRIVATE KEY`, rather than `BEGIN RSA PRIVATE KEY`). However, this will be a problem on CI where the OpenSSH is old enough that it doesn't support the new format at all.

So, to make sure that the keys are always compatible with all systems, let's force DocumenterTools to generate them in PEM, which should be lowest common denominator.

X-ref: https://serverfault.com/questions/939909/ssh-keygen-does-not-create-rsa-private-key