### PR TITLE
bump compat version for Sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DocumenterTools.jl changelog
 
+## Version `v0.1.10`
+
+* Declare compatibility with Sass.jl 0.2. ([#49][github-49])
+
 ## Version `v0.1.9`
 
 * Declare compatibility with Documenter 0.26. ([#46][github-46])
@@ -55,6 +59,7 @@ Maintenance release declaring compatibility with Documenter 0.25. ([#39][github-
 [github-43]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/43
 [github-44]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/44
 [github-46]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/46
+[github-49]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/49
 
 
 [badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocumenterTools"
 uuid = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Sass = "322a6be2-4ae8-5d68-aaf1-3e960788d1d9"
 [compat]
 DocStringExtensions = "0.7, 0.8"
 Documenter = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26"
-Sass = "0.1"
+Sass = "0.1, 0.2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
not sure why CompatHelper didn't create a PR, perhaps it was disabled by github?