### PR TITLE
Use OpenSSH_jll for ssh-keygen

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,10 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # DocumenterTools.jl changelog
 
+## Unreleased
+
+* DocumenterTools now requires at least Julia 1.6.
+* ![Enhancement][badge-enhancement] `DocumenterTools.genkeys` function now uses the `OpenSSH_jll` for the `ssh-keygen` binary and therefore no longer requires the user to have OpenSSH installed. ([#36][github-36], [#56][github-56])
+
 ## Version `v0.1.13`
 
 * ![Enhancement][badge-enhancement] The wording of the text in the the old version warning box was improved. ([#54][github-54])
@@ -66,6 +71,7 @@ Maintenance release declaring compatibility with Documenter 0.25. ([#39][github-
 [github-32]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/32
 [github-33]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/33
 [github-35]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/35
+[github-36]: https://github.com/JuliaDocs/DocumenterTools.jl/issues/36
 [github-39]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/39
 [github-40]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/40
 [github-43]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/43
@@ -75,6 +81,7 @@ Maintenance release declaring compatibility with Documenter 0.25. ([#39][github-
 [github-51]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/51
 [github-52]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/52
 [github-54]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/54
+[github-56]: https://github.com/JuliaDocs/DocumenterTools.jl/pull/56
 
 
 [badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ AbstractTrees = "0.3"
 DocStringExtensions = "0.7, 0.8"
 Documenter = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27"
 Gumbo = "0.7, 0.8"
+OpenSSH_jll = "8"
 Sass = "0.1, 0.2"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 Gumbo = "708ec375-b3d6-5a57-a7ce-8257bf98657a"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+OpenSSH_jll = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
 Sass = "322a6be2-4ae8-5d68-aaf1-3e960788d1d9"
 
 [compat]
@@ -18,7 +19,7 @@ DocStringExtensions = "0.7, 0.8"
 Documenter = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27"
 Gumbo = "0.7, 0.8"
 Sass = "0.1, 0.2"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"

--- a/src/genkeys.jl
+++ b/src/genkeys.jl
@@ -58,12 +58,7 @@ function genkeys(; user="\$USER", repo="\$REPO")
     isfile("$(filename).pub") && error("temporary file '$(filename).pub' already exists in working directory")
 
     # Generate the ssh key pair.
-    try
-        run(`$(sshkeygen) -N "" -C Documenter -f $filename`)
-    catch e
-        @error "failed to generate a SSH key pair" exception  = e
-        error("failed to generate a SSH key pair.")
-    end
+    success(`$(sshkeygen) -N "" -C Documenter -f $filename`) || error("failed to generate a SSH key pair.")
 
     # Prompt user to add public key to github then remove the public key.
     let url = "https://github.com/$user/$repo/settings/keys"

--- a/src/genkeys.jl
+++ b/src/genkeys.jl
@@ -58,7 +58,12 @@ function genkeys(; user="\$USER", repo="\$REPO")
     isfile("$(filename).pub") && error("temporary file '$(filename).pub' already exists in working directory")
 
     # Generate the ssh key pair.
-    success(`$(sshkeygen) -N "" -C Documenter -f $filename`) || error("failed to generate a SSH key pair.")
+    try
+        run(`$(sshkeygen) -N "" -C Documenter -f $filename`)
+    catch e
+        @error "failed to generate a SSH key pair" exception  = e
+        error("failed to generate a SSH key pair.")
+    end
 
     # Prompt user to add public key to github then remove the public key.
     let url = "https://github.com/$user/$repo/settings/keys"

--- a/src/genkeys.jl
+++ b/src/genkeys.jl
@@ -52,8 +52,6 @@ LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBNnpiRkdXQVZpYlIy
 """
 function genkeys(; user="\$USER", repo="\$REPO")
     sshkeygen = ssh_keygen()
-    @show sshkeygen[1]
-    @assert isfile(sshkeygen[1])
 
     filename  = "documenter-private-key"
     isfile(filename) && error("temporary file '$(filename)' already exists in working directory")

--- a/src/genkeys.jl
+++ b/src/genkeys.jl
@@ -11,6 +11,7 @@ end # module
 
 using Base64
 import LibGit2: GITHUB_REGEX
+using OpenSSH_jll: ssh_keygen
 
 """
     DocumenterTools.genkeys(; user="\$USER", repo="\$REPO")
@@ -23,12 +24,6 @@ The optional `user` and `repo` keyword arguments can be specified so that the UR
 printed instructions could be copied directly. They should be the name of the GitHub user or
 organization where the repository is hosted and the full name of the repository,
 respectively.
-
-This method of [`genkeys`](@ref) requires the following command lines programs to be
-installed:
-
-- `which` (Unix) or `where` (Windows)
-- `ssh-keygen`
 
 # Examples
 
@@ -56,24 +51,14 @@ LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBNnpiRkdXQVZpYlIy
 ```
 """
 function genkeys(; user="\$USER", repo="\$REPO")
-    # Error checking. Do the required programs exist?
-    if Sys.iswindows()
-        success(`where where`)      || error("'where' not found.")
-        success(`where ssh-keygen`) || error("'ssh-keygen' not found.")
-    else
-        success(`which which`)      || error("'which' not found.")
-        success(`which ssh-keygen`) || error("'ssh-keygen' not found.")
-    end
+    sshkeygen = ssh_keygen()
 
-
-    directory = pwd()
     filename  = "documenter-private-key"
-
     isfile(filename) && error("temporary file '$(filename)' already exists in working directory")
     isfile("$(filename).pub") && error("temporary file '$(filename).pub' already exists in working directory")
 
     # Generate the ssh key pair.
-    success(`ssh-keygen -N "" -C Documenter -f $filename`) || error("failed to generate a SSH key pair.")
+    success(`$(sshkeygen) -N "" -C Documenter -f $filename`) || error("failed to generate a SSH key pair.")
 
     # Prompt user to add public key to github then remove the public key.
     let url = "https://github.com/$user/$repo/settings/keys"
@@ -109,7 +94,6 @@ This method requires the following command lines programs to be installed:
 
 - `which` (Unix) or `where` (Windows)
 - `git`
-- `ssh-keygen`
 
 !!! note
     The package must be in development mode. Make sure you run
@@ -135,11 +119,9 @@ function genkeys(package::Module; remote="origin")
     # Error checking. Do the required programs exist?
     if Sys.iswindows()
         success(`where where`)      || error("'where' not found.")
-        success(`where ssh-keygen`) || error("'ssh-keygen' not found.")
         success(`where git`)        || error("'git' not found.")
     else
         success(`which which`)      || error("'which' not found.")
-        success(`which ssh-keygen`) || error("'ssh-keygen' not found.")
         success(`which git`)        || error("'git' not found.")
     end
 

--- a/src/genkeys.jl
+++ b/src/genkeys.jl
@@ -52,6 +52,8 @@ LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBNnpiRkdXQVZpYlIy
 """
 function genkeys(; user="\$USER", repo="\$REPO")
     sshkeygen = ssh_keygen()
+    @show sshkeygen[1]
+    @assert isfile(sshkeygen[1])
 
     filename  = "documenter-private-key"
     isfile(filename) && error("temporary file '$(filename)' already exists in working directory")


### PR DESCRIPTION
This means DocumenterTools will require Julia 1.6, but I think that's completely fine for this package.

Fix #36, close #38, close #37.