### PR TITLE
Bump compat bound for DocStringExtensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Sass = "322a6be2-4ae8-5d68-aaf1-3e960788d1d9"
 
 [compat]
 AbstractTrees = "0.3"
-DocStringExtensions = "0.7, 0.8"
+DocStringExtensions = "0.7, 0.8, 0.9"
 Documenter = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27"
 Gumbo = "0.7, 0.8"
 OpenSSH_jll = "8"


### PR DESCRIPTION
Otherwise the last version of DocStringExtensions can't be used in packages, which is a bit annoying because the docs will fail while the package will build correctly (assuming the package only depends on DocStringExtensions, and then version requirements can't be satisfied when building docs which depend on DocumenterTools, see [this failed job](https://github.com/serenity4/WindowAbstractions.jl/runs/6827952133?check_suite_focus=true)).