### PR TITLE
tests: run outdated warning test in a temporary directory

### DIFF
--- a/test/outdated.jl
+++ b/test/outdated.jl
@@ -11,8 +11,6 @@ mktempdir() do TMP
     # The following is sensitive to how Gumbo.jl writes HTML, but let's hope that doesn't change often:
     @test replace(output, "\r\n" => "\n") == replace(read(joinpath(@__DIR__, "fixtures", "index_after.html"), String), "\r\n" => "\n")
 
-    rm(index_changed)
-
 
     transient_path = joinpath(TMP, "fixtures", "transient")
     cp(joinpath(TMP, "fixtures", "pre"), transient_path, force=true)
@@ -26,5 +24,5 @@ mktempdir() do TMP
         end
     end
 
-    rm(transient_path, recursive=true)
+    rm(joinpath(TMP, "fixtures"), recursive=true)
 end

--- a/test/outdated.jl
+++ b/test/outdated.jl
@@ -1,25 +1,30 @@
-index_changed = joinpath(@__DIR__, "fixtures", "index_changed.html")
-cp(joinpath(@__DIR__, "fixtures", "index.html"), index_changed, force=true)
-OutdatedWarning.add_old_docs_notice(index_changed)
-output = read(index_changed, String)
+mktempdir() do TMP
+    cp(joinpath(@__DIR__, "fixtures"), joinpath(TMP, "fixtures"))
+    chmod(joinpath(TMP, "fixtures"), 0o777, recursive=true)
 
-@test occursin("data-outdated-warner", output)
-# The following is sensitive to how Gumbo.jl writes HTML, but let's hope that doesn't change often:
-@test replace(output, "\r\n" => "\n") == replace(read(joinpath(@__DIR__, "fixtures", "index_after.html"), String), "\r\n" => "\n")
+    index_changed = joinpath(TMP, "fixtures", "index_changed.html")
+    cp(joinpath(TMP, "fixtures", "index.html"), index_changed, force=true)
+    OutdatedWarning.add_old_docs_notice(index_changed)
+    output = read(index_changed, String)
 
-rm(index_changed)
+    @test occursin("data-outdated-warner", output)
+    # The following is sensitive to how Gumbo.jl writes HTML, but let's hope that doesn't change often:
+    @test replace(output, "\r\n" => "\n") == replace(read(joinpath(@__DIR__, "fixtures", "index_after.html"), String), "\r\n" => "\n")
+
+    rm(index_changed)
 
 
-transient_path = joinpath(@__DIR__, "fixtures", "transient")
-cp(joinpath(@__DIR__, "fixtures", "pre"), transient_path, force=true)
-OutdatedWarning.generate(transient_path)
+    transient_path = joinpath(TMP, "fixtures", "transient")
+    cp(joinpath(TMP, "fixtures", "pre"), transient_path, force=true)
+    OutdatedWarning.generate(transient_path)
 
-for (root, _, files) in walkdir(transient_path)
-    for file in files
-        content = read(joinpath(root, file), String)
-        expected = read(joinpath(replace(root, "transient" => "post"), file), String)
-        @test replace(content, "\r\n" => "\n") == replace(expected, "\r\n" => "\n")
+    for (root, _, files) in walkdir(transient_path)
+        for file in files
+            content = read(joinpath(root, file), String)
+            expected = read(joinpath(replace(root, "transient" => "post"), file), String)
+            @test replace(content, "\r\n" => "\n") == replace(expected, "\r\n" => "\n")
+        end
     end
-end
 
-rm(transient_path, recursive=true)
+    rm(transient_path, recursive=true)
+end


### PR DESCRIPTION
If the tests are run on a `Pkg.add`-ed package, these tests will fail because the files are generally read-only. So for good measure, let's copy everything to a temporary directory, and also update their permissions.

This should allow the package to also pass PkgEval where it is currently failing due to this.