### PR TITLE
Add a walkdocs function to walk over all HTML files of a docs directory

### DIFF
--- a/src/DocumenterTools.jl
+++ b/src/DocumenterTools.jl
@@ -174,6 +174,7 @@ function package_devpath(pkg::Module)
     return normpath(joinpath(path, "..", ".."))
 end
 
+include("walkdocs.jl")
 include("genkeys.jl")
 include("Generator.jl")
 include("Themes.jl")

--- a/src/walkdocs.jl
+++ b/src/walkdocs.jl
@@ -1,0 +1,41 @@
+"""
+    walkdocs(f, dir::AbstractString; collect::Bool=false)
+
+Takes a directory `dir`, which is assumed to contain Documenter-generated HTML documentation,
+walks over all the files and calls `f` on each of the HTML files it find. `f` will be called
+with a single object that has the following fields (all strings):
+
+- `root`: the root directory of the walk, i.e. `dir` (but as an absolute path)
+- `filename`: file name
+- `relpath`: path to the file, relative to `dir`
+- `fullpath`: absolute path to the file
+
+If `collect = true` is set, the function also "collects" all the return values from `f`
+from each of the function calls, essentially making `walkdocs` behave like a `map` function
+applied on each of the HTML files.
+"""
+function walkdocs(f, dir::AbstractString; collect::Bool=false)
+    dir = abspath(dir)
+    isdir(dir) || error("docwalker: dir is not a directory\n dir = $(dir)")
+
+    mapped_collection = collect ? Any[] : nothing
+    for (root, _, files) in walkdir(dir)
+        for file in files
+            _, ext = splitext(file)
+            (ext == ".html") || continue
+            file_fullpath = joinpath(root, file)
+            file_relpath = Base.relpath(file_fullpath, dir)
+            fileinfo = (;
+                root = dir,
+                filename = file,
+                relpath = file_relpath,
+                fullpath = file_fullpath,
+            )
+            r = f(fileinfo)
+            if collect
+                push!(mapped_collection, r)
+            end
+        end
+    end
+    return mapped_collection
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,10 @@ import Documenter
         DocumenterTools.genkeys(DocumenterMarkdown)
     end
 
+    @testset "walkdocs" begin
+        include("walkdocs.jl")
+    end
+
     @testset "outdated warnings" begin
         include("outdated.jl")
     end

--- a/test/walkdocs.jl
+++ b/test/walkdocs.jl
@@ -1,0 +1,19 @@
+let fileinfos = []
+    rs = DocumenterTools.walkdocs(joinpath(@__DIR__, "fixtures")) do fileinfo
+        push!(fileinfos, fileinfo)
+
+        @test isabspath(fileinfo.root)
+        @test isabspath(fileinfo.fullpath)
+        @test !isabspath(fileinfo.relpath)
+        @test joinpath(fileinfo.root, fileinfo.relpath) == fileinfo.fullpath
+    end
+    @test rs === nothing
+    @test length(fileinfos) == 10
+end
+
+let rs = DocumenterTools.walkdocs(joinpath(@__DIR__, "fixtures"), collect=true) do fileinfo
+        fileinfo.root
+    end
+    @test length(rs) == 10
+    @test all(s -> isa(s, String), rs)
+end


### PR DESCRIPTION
It's a pretty common operation to want to do some operation on every HTML file of a Documenter build. E.g. to figure out the sizes of all HTML files:

```
filesizes = DocumenterTools.walkdocs("docs/build"; collect=true) do fileinfo
    fileinfo.relpath => filesize(fileinfo.fullpath)
end
```