### PR TITLE
docs: fix URL in a docstring

### DIFF
--- a/src/DocumenterTools.jl
+++ b/src/DocumenterTools.jl
@@ -35,7 +35,7 @@ Project.toml
 
 **`format`** can be either `:html` (default), `:markdown` or `:pdf` corresponding
 to the `format` keyword to Documenter's `makedocs` function, see
-[Documenter's manual](https://juliadocs.github.io/Documenter.jl/stable/man/other-formats/).
+[Documenter's manual](https://documenter.juliadocs.org/stable/man/other-formats/).
 
 # Examples
 ```julia-repl


### PR DESCRIPTION
Warns in Documenter's linkcheck.