### PR TITLE
Update description of DOCUMENTER_KEY to 'Repository secret'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DocumenterTools.jl changelog
 
+## Version `v0.1.19`
+
+* Update the instructions about the GitHub interface `genkeys` prints. ([#84][github-84], [#85][github-85])
+
 ## Version `v0.1.18`
 
 * Declare compatibility with Documenter 1.0. ([#80][github-80], [#81][github-81])

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocumenterTools"
 uuid = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
-version = "0.1.18"
+version = "0.1.19"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/genkeys.jl
+++ b/src/genkeys.jl
@@ -36,7 +36,7 @@ julia> DocumenterTools.genkeys()
 
 ssh-rsa AAAAB3NzaC2yc2EAAAaDAQABAAABAQDrNsUZYBWJtXYUk21wxZbX3KxcH8EqzR3ZdTna0Wgk...jNmUiGEMKrr0aqQMZEL2BG7 Documenter
 
-[ Info: Add a secure environment variable named 'DOCUMENTER_KEY' (to https://github.com/\$USER/\$REPO/settings/secrets if you deploy using GitHub Actions) with value:
+[ Info: Add a secure 'Repository secret' named 'DOCUMENTER_KEY' (to https://github.com/\$USER/\$REPO/settings/secrets if you deploy using GitHub Actions) with value:
 
 LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBNnpiRkdXQVZpYlIy...QkVBRWFjY3BxaW9uNjFLaVdOcDU5T2YrUkdmCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
 
@@ -47,7 +47,7 @@ julia> DocumenterTools.genkeys(user="JuliaDocs", repo="DocumenterTools.jl")
 
 ssh-rsa AAAAB3NzaC2yc2EAAAaDAQABAAABAQDrNsUZYBWJtXYUk21wxZbX3KxcH8EqzR3ZdTna0Wgk...jNmUiGEMKrr0aqQMZEL2BG7 Documenter
 
-[ Info: Add a secure environment variable named 'DOCUMENTER_KEY' (to https://github.com/JuliaDocs/DocumenterTools.jl/settings/secrets if you deploy using GitHub Actions) with value:
+[ Info: Add a secure 'Repository secret' named 'DOCUMENTER_KEY' (to https://github.com/JuliaDocs/DocumenterTools.jl/settings/secrets if you deploy using GitHub Actions) with value:
 
 LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBNnpiRkdXQVZpYlIy...QkVBRWFjY3BxaW9uNjFLaVdOcDU5T2YrUkdmCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
 ```
@@ -80,7 +80,7 @@ function genkeys(; user="\$USER", repo="\$REPO")
                 # *not* encoded for the sake of security, but instead to make it easier to
                 # copy/paste it over to travis without having to worry about whitespace.
                 let github_url = "https://github.com/$user/$repo/settings/secrets"
-                    @info("Add a secure environment variable named 'DOCUMENTER_KEY' " *
+                    @info("Add a secure 'Repository secret' named 'DOCUMENTER_KEY' " *
                         "(to $(github_url) if you deploy using GitHub Actions) with value:")
                     println("\n", base64encode(read(filename, String)), "\n")
                 end
@@ -132,7 +132,7 @@ julia> DocumenterTools.genkeys(DocumenterTools)
 
 ssh-rsa AAAAB3NzaC2yc2EAAAaDAQABAAABAQDrNsUZYBWJtXYUk21wxZbX3KxcH8EqzR3ZdTna0Wgk...jNmUiGEMKrr0aqQMZEL2BG7 username@hostname
 
-[ Info: add a secure environment variable named 'DOCUMENTER_KEY' to https://travis-ci.com/JuliaDocs/DocumenterTools.jl/settings (if you deploy using Travis CI) or https://github.com/JuliaDocs/DocumenterTools.jl/settings/secrets (if you deploy using GitHub Actions) with value:
+[ Info: add a secure 'Repository secret' named 'DOCUMENTER_KEY' to https://travis-ci.com/JuliaDocs/DocumenterTools.jl/settings (if you deploy using Travis CI) or https://github.com/JuliaDocs/DocumenterTools.jl/settings/secrets (if you deploy using GitHub Actions) with value:
 
 LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBNnpiRkdXQVZpYlIy...QkVBRWFjY3BxaW9uNjFLaVdOcDU5T2YrUkdmCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
 ```


### PR DESCRIPTION
The new GitHub UI shows "Secrets" and "Variables" as two different tabs, and there are "Environment secrets" and "Repository secrets", and we want the latter. This caused some confusion among colleagues new to Julia and GitHub, so I think the changes are warranted.

I think this closes #84. 

Here is a screenshot of the '../settings/secrets' page:

![image](https://github.com/JuliaDocs/DocumenterTools.jl/assets/1068752/78b2fb67-d970-4cf9-9573-3bca3217e4c5)
